### PR TITLE
Fixed issue where selector didn't work on group chats and marketplace

### DIFF
--- a/src/jsx/EmojiPicker.jsx
+++ b/src/jsx/EmojiPicker.jsx
@@ -26,7 +26,7 @@ export default class EmojiPicker extends Component {
   componentWillUnmount() {
     this.observer.disconnect();
 
-    const textEditor = document.querySelector('div[contenteditable=true]');
+    const textEditor = document.querySelector('div[contenteditable=true][role=combobox]');
     textEditor.removeEventListener('keydown', this.trackKeyboardNavigation);
     textEditor.removeEventListener('click', this.onContentChange);
   }
@@ -162,7 +162,7 @@ export default class EmojiPicker extends Component {
   }
 
   onEmojiSelection = () => {
-    document.querySelector('div[contenteditable=true]').focus();
+    document.querySelector('div[contenteditable=true][role=combobox]').focus();
     this.transformEmojiZoneToEmoji(this.state.nodeText, this.state.cursor, false);
 
     this.setState({
@@ -174,7 +174,7 @@ export default class EmojiPicker extends Component {
    * track text editor and emoji picker
    */
   trackEvents = () => {
-    const textEditor = document.querySelector('div[contenteditable=true]');
+    const textEditor = document.querySelector('div[contenteditable=true][role=combobox]');
 
     // handle all insertion and deletion by listening to DOM mutations to text editor div
     this.observer = new MutationObserver((mutationRecords) => {


### PR DESCRIPTION
When in group chats or Marketplace chats, you can edit the title of the chat, which means there are two occurrences on those pages. querySelector takes the first by default.

Added `role=combobox` to the selector, because the chat input element has that, while the other ones do not.